### PR TITLE
iptables chain references popup fix

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -202,7 +202,7 @@ return view.extend({
 				var refs = chain_refs[cdiv.getAttribute('data-chain')];
 				if (refs && refs.length) {
 					rspan.classList.add('cbi-tooltip-container');
-					rspan.appendChild(E('small', { 'class': 'cbi-tooltip ifacebadge', 'style': 'top:1em; left:auto' }, [ E('ul') ]));
+					rspan.appendChild(E('small', { 'class': 'cbi-tooltip fwchainref', 'style': 'top:1em; left:auto' }, [ E('ul') ]));
 
 					refs.forEach(L.bind(function(ref) {
 						var chain = ref[0].parentNode.getAttribute('data-chain'),

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1803,13 +1803,13 @@ body.modal-overlay-active #modal_overlay {
 	background: var(--background-color-high);
 	white-space: pre;
 	padding: 2px 5px;
-	opacity: 0;
+	display: none;
 	transition: opacity .25s ease-in;
 }
 
 .cbi-tooltip-container:hover .cbi-tooltip:not(:empty) {
 	left: auto;
-	opacity: 1;
+	display: inline-block;
 	transition: opacity .25s ease-in;
 }
 
@@ -2190,6 +2190,9 @@ th[data-sort-direction="desc"]::after { content: "\a0\25bc"; }
 
 .ifacebadge {
 	display: inline-block;
+}
+
+.ifacebadge, .fwchainref {
 	flex-direction: row;
 	border: 1px solid var(--border-color-high);
 	padding: 2px;


### PR DESCRIPTION
Switching from opacity to display prevents the mouse from interacting with the otherwise invisible popup (which renders everything below it on the z-axis inaccessible).